### PR TITLE
Tjf 1735

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.totvs.tjf</groupId>
 		<artifactId>tjf-boot-starter</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.totvs.tjf</groupId>
 		<artifactId>tjf-boot-starter</artifactId>
-		<version>5.0.0-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 

--- a/tjf-core-samples/tjf-core-validation-sample/README.md
+++ b/tjf-core-samples/tjf-core-validation-sample/README.md
@@ -36,7 +36,7 @@ Como iremos criar uma API REST, para facilitar a criação do modelo, vamos util
   <groupId>org.projectlombok</groupId>
   <artifactId>lombok</artifactId>
 </dependency>
-```
+```xml
 
 > Saiba mais sobre o o [Lombok](https://projectlombok.org/).
 
@@ -57,6 +57,16 @@ Também adicionaremos o Spring Fox Swagger como dependência para a demonstraç�
 ```
 
 > Saiba mais sobre o [Spring Fox Swagger](https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api).
+
+O Spring Fox Swagger assume a correspondencia de caminho Ant-based e não por PathPattern que é padrão do Spring Boot a partir da versão 2.6. 
+
+Para contornar a situação vamos modificar as propriedades do Spring Boot para esse exemplo. Para isso criaremos uma pasta resources em src/main e um arquivo application.properties com a seguinte configuração:
+
+```xml
+
+	spring.mvc.pathmatch.matching-strategy = ant-path-matcher;
+
+```
 
 ## Criando o código fonte
 

--- a/tjf-core-samples/tjf-core-validation-sample/pom.xml
+++ b/tjf-core-samples/tjf-core-validation-sample/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.totvs.tjf</groupId>
 		<artifactId>tjf-boot-starter</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 

--- a/tjf-core-samples/tjf-core-validation-sample/pom.xml
+++ b/tjf-core-samples/tjf-core-validation-sample/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.totvs.tjf</groupId>
 		<artifactId>tjf-boot-starter</artifactId>
-		<version>5.0.0-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -26,14 +26,13 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
-		<!-- ISSUE TJF-1735 - tjf-core-validation-sample ocorrendo erro com o Swagger
 			<dependency>
 				<groupId>io.springfox</groupId>
 				<artifactId>springfox-swagger2</artifactId>
 				<version>3.0.0</version>
 			</dependency>
-		-->
-
+		
+	
 		<!-- Lombok -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/tjf-core-samples/tjf-core-validation-sample/src/main/java/com/tjf/sample/github/corevalidation/SwaggerConfiguration.java
+++ b/tjf-core-samples/tjf-core-validation-sample/src/main/java/com/tjf/sample/github/corevalidation/SwaggerConfiguration.java
@@ -1,7 +1,7 @@
 package com.tjf.sample.github.corevalidation;
 
-/* ISSUE TJF-1735 - tjf-core-validation-sample ocorrendo erro com o Swagger
-import org.springframework.context.annotation.Bean;/
+/* ISSUE TJF-1735 - tjf-core-validation-sample ocorrendo erro com o Swagger */
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import springfox.documentation.builders.PathSelectors;
@@ -21,6 +21,7 @@ public class SwaggerConfiguration {
 	}
 
 }
-*/
 
+/*
 public class SwaggerConfiguration {}
+*/

--- a/tjf-core-samples/tjf-core-validation-sample/src/main/java/com/tjf/sample/github/corevalidation/model/AccountModel.java
+++ b/tjf-core-samples/tjf-core-validation-sample/src/main/java/com/tjf/sample/github/corevalidation/model/AccountModel.java
@@ -31,4 +31,6 @@ public class AccountModel {
 	@Max(value = 1000, message = "Valor maximo é 1000!")
 	private Double balance;
 
+	
+
 }

--- a/tjf-core-samples/tjf-core-validation-sample/src/main/resources/application.properties
+++ b/tjf-core-samples/tjf-core-validation-sample/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.mvc.pathmatch.matching-strategy = ant-path-matcher;

--- a/tjf-core-samples/tjf-core-validation-sample/src/test/java/com/tjf/sample/github/corevalidation/ErrorResponse.java
+++ b/tjf-core-samples/tjf-core-validation-sample/src/test/java/com/tjf/sample/github/corevalidation/ErrorResponse.java
@@ -14,5 +14,5 @@ public class ErrorResponse {
 	private final String error;
 	private final String message;
 	private final String path;
-
+	
 }


### PR DESCRIPTION
O Spring Fox Swagger está assumindo que a correspondência de caminho do MVC usará o correspondente de caminho baseado em Ant e não o correspondente baseado em PathPattern que passou a ser padrão após o Spring Boot 2.6.

Modificação para restaurar a configuração que o Springfox assume colocando spring.mvc.pathmatch.matching-strategy como ant-path-matche em resources/application.properties.