### PR TITLE
fix renderer README.md

### DIFF
--- a/tjf-core-samples/tjf-core-validation-sample/README.md
+++ b/tjf-core-samples/tjf-core-validation-sample/README.md
@@ -38,7 +38,7 @@ Como iremos criar uma API REST, para facilitar a criação do modelo, vamos util
 </dependency>
 ```
 
-> Saiba mais sobre o o [Lombok](https://projectlombok.org/).
+> Saiba mais sobre o [Lombok](https://projectlombok.org/).
 
 Também adicionaremos o Spring Fox Swagger como dependência para a demonstração:
 

--- a/tjf-core-samples/tjf-core-validation-sample/README.md
+++ b/tjf-core-samples/tjf-core-validation-sample/README.md
@@ -36,7 +36,7 @@ Como iremos criar uma API REST, para facilitar a criação do modelo, vamos util
   <groupId>org.projectlombok</groupId>
   <artifactId>lombok</artifactId>
 </dependency>
-```xml
+```
 
 > Saiba mais sobre o o [Lombok](https://projectlombok.org/).
 


### PR DESCRIPTION
A renderização do trecho estava sendo afetada pela string "xml" desnecessária após o fechamento de code md